### PR TITLE
fix  a bug in merge_task

### DIFF
--- a/onedrived/common/tasks/merge_task.py
+++ b/onedrived/common/tasks/merge_task.py
@@ -97,7 +97,7 @@ class MergeDirTask(TaskBase):
         :param [str] all_local_items: All remaining untouched local items.
         """
         item_local_path = self.local_path + '/' + remote_item.name
-        q = self.items_store.get_items_by_id(parent_path=self.remote_path, item_name=remote_item.name)
+        q = self.items_store.get_items_by_id(parent_path=self.remote_parent_path, item_name=remote_item.name)
         exists = os.path.exists(item_local_path)
         has_record = len(q) > 0
         if not has_record and not exists:


### PR DESCRIPTION
The function get_items_by_id nees parent_path. if we use self.remote_path to select the directories in root directory. the self.remote_path is '/drive/root:/', but in database table item, the parent_path is '/drive/root:'.  so  the select operation will never success.